### PR TITLE
shared=False 일 경우 shared library 는 패키징 하지 않도록 수정

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,8 @@ class HiredisConan(ConanFile):
 
     def package(self):
         self.copy("*.h", dst="include", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
+        if self.options["shared"]:
+            self.copy("*.so", dst="lib", keep_path=False)
         self.copy("*.dylib", dst="lib", keep_path=False)
         self.copy("*.a", dst="lib", keep_path=False)
 


### PR DESCRIPTION
shared=False 일 경우 shared library 는 패키징 하지 않도록 수정